### PR TITLE
Support strong session key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The example of configuration file.
 address: ":18081" # listen address
 
 # secret tokens to authenticate/encrypt cookie.
-# see http://www.gorillatoolkit.org/pkg/sessions for more detail
+# see http://www.gorillatoolkit.org/pkg/sessions for more detail.
+# use `-genkey` option to create strong keys.
 secrets:
   - new-authentication-key
   - new-encryption-key
@@ -37,8 +38,8 @@ cookie:
   path: /
   domain:
   max_age: 0
-  secure: false
-  http_only: false
+  secure: true # default: false. It is recommended to set true.
+  http_only: true # default: false. It is recommended to set true.
 
 providers:
   # development: {} # For test.

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -1,0 +1,124 @@
+package adapter
+
+import (
+	"testing"
+)
+
+func TestNewServer(t *testing.T) {
+	String := func(s string) *string {
+		return &s
+	}
+	dummyProvidor := map[string]map[string]interface{}{"development": {}}
+
+	testcases := []struct {
+		err bool
+		c   Config
+	}{
+		// fail with "provider configure not found" error.
+		{
+			err: true,
+			c:   Config{},
+		},
+
+		// test "the session authentication key is empty" error.
+		{
+			err: false, // just warn in running.
+			c: Config{
+				Providers: dummyProvidor,
+			},
+		},
+		{
+			err: true, // fail in testing the config.
+			c: Config{
+				Providers:  dummyProvidor,
+				ConfigTest: true,
+			},
+		},
+
+		// check session authentication key length.
+		{
+			err: false, // the secret is 32 bytes, and it's valid.
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{String("dummy-session-authentication-key")},
+			},
+		},
+		{
+			err: true, // the secret is 33 bytes, and it's invalid.
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{String("dummy-session-authentication-key+")},
+			},
+		},
+		{
+			err: false, // valid hex string
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{String("8e26ea01bd8805788bcb4660c7c15692e4771b5d6a22635eede025ca544ad4a00bcd17295f1ca8a5d573899fc7a641a25f488c9a5e839368cd79c2ffe1028031")},
+			},
+		},
+		{
+			err: true, // invalid hex string
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{String("INVALID-HEX-05788bcb4660c7c15692e4771b5d6a22635eede025ca544ad4a00bcd17295f1ca8a5d573899fc7a641a25f488c9a5e839368cd79c2ffe1028031")},
+			},
+		},
+
+		// check session encryption key length.
+		{
+			err: false, // the secret is 32 bytes, and it's valid.
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{nil, String("**dummy-session-encryption-key**")},
+			},
+		},
+		{
+			err: true, // the secret is 33 bytes, and it's invalid.
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{nil, String("dummy-session-encryption-key")},
+			},
+		},
+		{
+			err: false, // valid hex string
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{nil, String("5c9ea31b400099a521f934f8a4c2c88758ca59e0a34479775aea86404921658e")},
+			},
+		},
+		{
+			err: true, // invalid hex string
+			c: Config{
+				Providers: dummyProvidor,
+				Secrets:   []*string{nil, String("INVALID-HEX-5c9ea31b400099a521f934f8a4c2c88758ca59e0a34479775aea")},
+			},
+		},
+
+		// invalid duration.
+		{
+			err: true,
+			c: Config{
+				Providers:          dummyProvidor,
+				AppRefreshInterval: "hoge",
+			},
+		},
+	}
+
+	for i, tc := range testcases {
+		s, err := NewServer(tc.c)
+		t.Logf("%d %#v: %v, %v", i, tc.c, s, err)
+		if tc.err {
+			if err == nil {
+				t.Errorf("%v: expected error, got no error", tc.c)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%v: expected no error, got %v", tc.c, err)
+			}
+		}
+		if err != nil {
+			continue
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	Providers          map[string]map[string]interface{} `yaml:"providers" json:"providers"`
 	AppRefreshInterval string                            `yaml:"app_refresh_interval" json:"app_refresh_interval"`
 
+	// set with -configtest option.
+	ConfigTest bool `yaml:"-" json:"-"`
+
 	// Fields are a subset of http.Cookie fields.
 	Cookie *CookieConfig `yaml:"cookie" json:"cookie"`
 }
@@ -105,6 +108,9 @@ func (c *Config) LoadEnv() error {
 
 // Options returns the sesseion config.
 func (c *CookieConfig) Options() *sessions.Options {
+	if c == nil {
+		return &sessions.Options{}
+	}
 	return &sessions.Options{
 		Path:     c.Path,
 		Domain:   c.Domain,

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func Main(args []string) int {
 
 	if genKey {
 		fmt.Println(hex.EncodeToString(securecookie.GenerateRandomKey(64)))
-		fmt.Println(hex.EncodeToString(securecookie.GenerateRandomKey(64)))
+		fmt.Println(hex.EncodeToString(securecookie.GenerateRandomKey(32)))
 		return 0
 	}
 

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func Main(args []string) int {
 		}).Error("error while parsing configure")
 		return 1
 	}
+	c.ConfigTest = configtest
 
 	s, err := NewServer(*c)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is the version of go-nginx-oauth2-adapter.
-const Version = "0.2.1"
+const Version = "0.3.0-rc1"
 
 // Main starts the go-nginx-oauth2-adapter server.
 func Main(args []string) int {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gorilla/securecookie"
 	"github.com/lestrrat/go-server-starter/listener"
 	"github.com/sirupsen/logrus"
 )
@@ -26,6 +28,7 @@ func Main(args []string) int {
 	var configtest bool
 	var showVersion bool
 	var showHelp bool
+	var genKey bool
 	flagSet.StringVar(&configFile, "c", "", "configuration file")
 	flagSet.StringVar(&configFile, "config", "", "configuration file")
 	flagSet.BoolVar(&configtest, "t", false, "test configuration and exit")
@@ -34,6 +37,8 @@ func Main(args []string) int {
 	flagSet.BoolVar(&showVersion, "version", false, "show version information")
 	flagSet.BoolVar(&showHelp, "h", false, "show help")
 	flagSet.BoolVar(&showHelp, "help", false, "show help")
+	flagSet.BoolVar(&genKey, "g", false, "shorthand of genkey")
+	flagSet.BoolVar(&genKey, "genkey", false, "generate random key for cookie")
 	err := flagSet.Parse(args[1:])
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
@@ -49,6 +54,12 @@ func Main(args []string) int {
 
 	if showHelp {
 		flagSet.Usage()
+		return 0
+	}
+
+	if genKey {
+		fmt.Println(hex.EncodeToString(securecookie.GenerateRandomKey(64)))
+		fmt.Println(hex.EncodeToString(securecookie.GenerateRandomKey(64)))
 		return 0
 	}
 

--- a/provider/google.go
+++ b/provider/google.go
@@ -142,7 +142,7 @@ func (pc *providerConfigGoogle) InfoContext(ctx context.Context, c *oauth2.Confi
 		return nil, errors.New("shogo82148/go-nginx-oauth2-adapter/provider: kid is not found")
 	})
 	if err != nil {
-		errors.New("shogo82148/go-nginx-oauth2-adapter/provider: fail to validate id_token")
+		return "", nil, errors.New("shogo82148/go-nginx-oauth2-adapter/provider: fail to validate id_token")
 	}
 	info["email"] = idType.Email
 


### PR DESCRIPTION
> It is recommended to use an authentication key with 32 or 64 bytes. The encryption key, if set, must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 modes.
> http://www.gorillatoolkit.org/pkg/sessions

- [x] add secure key generator
- [x] hex decode
- [x] verify key length
