### PR TITLE
fix memory leak in gorilla/sessions

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/context"
 	"github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 )
@@ -135,6 +136,8 @@ func NewServer(config Config) (*Server, error) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer context.Clear(r)
+
 	switch r.URL.Path {
 	case "/test":
 		s.HandlerTest(w, r)


### PR DESCRIPTION
メモリリークの修正PRです。
よろしくお願いします。

> Important Note: If you aren't using gorilla/mux, you need to wrap your handlers with context.ClearHandler as or else you will leak memory! An easy way to do this is to wrap the top-level mux when calling http.ListenAndServe:
>
> > http.ListenAndServe(":8080", context.ClearHandler(http.DefaultServeMux))
>
>The ClearHandler function is provided by the gorilla/context package.

http://www.gorillatoolkit.org/pkg/sessions より


ref: https://github.com/gorilla/context/blob/08b5f424b9271eedf6f9f0ce86cb9396ed337a42/context.go#L15

`gorilla/mux` ではこの `data[r]` を勝手に開放してくれますが、そうでない場合は自分で開放するしかありません。