### PR TITLE
Set session encryption block key from env vars

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/sessions"
 	"gopkg.in/yaml.v2"
@@ -88,7 +89,9 @@ func (c *Config) LoadEnv() error {
 	}
 
 	if v := os.Getenv("NGX_OMNIAUTH_SESSION_SECRET"); v != "" {
-		c.Secrets = []*string{&v}
+		for _, v := range strings.Split(v, ",") {
+			c.Secrets = append(c.Secrets, &v)
+		}
 	}
 
 	if v := os.Getenv("NGX_OMNIAUTH_SESSION_COOKIE_NAME"); v != "" {

--- a/config.go
+++ b/config.go
@@ -90,6 +90,7 @@ func (c *Config) LoadEnv() error {
 
 	if v := os.Getenv("NGX_OMNIAUTH_SESSION_SECRET"); v != "" {
 		for _, v := range strings.Split(v, ",") {
+			v := v
 			c.Secrets = append(c.Secrets, &v)
 		}
 	}


### PR DESCRIPTION
`NGX_OMNIAUTH_SESSION_SECRET` can sets only gorilla/sessions hash key.

To support payload encryption and key rotation, change `NGX_OMNIAUTH_SESSION_SECRET` to parse in a comma-delimited format.