### PR TITLE
fix building nginx

### DIFF
--- a/.github/install-nginx.sh
+++ b/.github/install-nginx.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-NGINX_VERSION=1.19.7
+NGINX_VERSION=1.30.0
 CURRENT=$(cd "$(dirname "$0")" && pwd)
 
 echo "$CURRENT/nginx/sbin" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies for building nginx and h2o
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies for building nginx and h2o
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libpcre2-dev
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies for building nginx and h2o
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libpcre2-dev
+          sudo apt-get install -y build-essential libpcre3 libpcre3-dev
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI test workflow now runs on Ubuntu 24.04 and updates system package indexes before installing additional build dependencies so tests that require native libraries can compile and run.
  * Packaged NGINX version updated from 1.19.7 to 1.30.0, providing a newer web server/runtime in development and CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->